### PR TITLE
packaging the design system app as an NPM module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "alfabit-design-system",
+  "name": "alfabit-ds-doc",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -40,5 +40,13 @@
     "@storybook/theming": "^7.0.23",
     "eslint-plugin-storybook": "^0.6.12",
     "storybook": "^7.0.12"
-  }
+  },
+  "files": [
+    "styles/globals.css",
+    "tailwind.config.js",
+    "components/*",
+    "fonts/*"
+  ],
+  "author": "Vinicius Cardozo <vinicius.gcardozo@gmail.com>",
+  "license": "ISC"
 }


### PR DESCRIPTION
1. Informar o NPM que a aplicação será empacotada em um package module 
    
    ```markdown
    npm init
    ```
    
    Após isso é só seguir com o login no NPM, se for o caso, e informar o nome do modulo.
    
2. Adicionar a propriedade `files` ao `package.json` com os seguintes itens:
    1. `styles/globals.css` - referência para o arquivo que define todas as variáveis css
    2. `tailwind.config.js` - referência para o arquivo que configura o tema do DS
    3. `components/*` - referência a todos os arquivos dentro da pasta de componentes
    4. `fonts/*` - referência a todas as fontes do DS
    
    Assim, no final deve ter algo parecido com isso: